### PR TITLE
Exclude bench-data from publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/sstadick/crabz"
 categories = ["compression", "concurrency"]
 keywords = ["compression", "parallel", "pigz"]
 description = "Parallel Compression"
+exclude = ["bench-data/"]
 
 [[bin]]
 name = "crabz"


### PR DESCRIPTION
Right now the .crate file published to crates.io is 2MB because it's shipping all the bench data. This means the bench data is going to be downloaded every time someone installs crabz via `cargo install`, and promptly thrown away. This is just wasteful.