### PR TITLE
feat: add --quiet flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,10 @@ struct Opts {
     /// - Instance 2 has `-p 4 -P 4` set indicating that it will use 4 cores pinned at 4, 5, 6, 7
     #[structopt(short = "P", long)]
     pin_at: Option<usize>,
+
+    /// Suppress non-error messages
+    #[structopt(short = "Q", long)]
+    quiet: bool,
 }
 
 fn main() -> Result<()> {
@@ -475,10 +479,14 @@ where
 }
 /// Parse args and set up logging / tracing
 fn setup() -> Opts {
-    if std::env::var("RUST_LOG").is_err() {
+    let opts = Opts::from_args();
+
+    if opts.quiet {
+        std::env::set_var("RUST_LOG", "error");
+    } else if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "info");
     }
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    Opts::from_args()
+    opts
 }


### PR DESCRIPTION
This PR addresses #28, adding a `--quiet` flag. Note this quick implementation is not a `--silent` flag, does not allow `-QQ`, and also does not include a `--verbose` flag. These would require further discussion.

